### PR TITLE
Add prompts for replacing RoadBlaster backgrounds

### DIFF
--- a/data/backgrounds/README.md
+++ b/data/backgrounds/README.md
@@ -1,0 +1,25 @@
+# Background assets audit
+
+The following background sources live under `data/backgrounds/`:
+
+- `hiscore.gfx_bg/Screenshot-RoadBlaster.mp4-39.gfx_bg.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+- `hud.gfx_directcolor/hud_xcf.png`
+- `levelcomplete.0.gfx_bg/Screenshot-RoadBlaster.mp4-50.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+- `levelcomplete.1.gfx_bg/Screenshot-RoadBlaster.mp4-38.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+- `levelcomplete.2.gfx_bg/Screenshot-RoadBlaster.mp4-23.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+- `logo.gfx_bg/logo.gfx_bg.png`
+- `msu1.gfx_bg/msu1.gfx_bg.png`
+- `scoreentry.gfx_bg/Screenshot-RoadBlaster.mp4-25.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+- `titlescreen.gfx_bg/Screenshot-RoadBlaster.mp4-24.png` *(RoadBlaster capture, needs Dragon's Lair replacement)*
+
+RoadBlaster-derived captures must be replaced with Dragon's Lair visuals. Prompts and SNES-ready constraints for each scene live in the per-directory `.gfx_bg.txt` files.
+
+Recreation workflow:
+- Pull a matching Dragon's Lair arcade frame as composition reference, then feed the paired prompt into your image generator to produce a 256x224 output.
+- Quantize to 4bpp with no more than 8 palettes (16 colors each, <=128 colors total) and verify the art stays tile-friendly before running `make` so the converter emits `.animation` data.
+
+Spot-check guidance once new art is produced:
+- Verify palette alignment with the SNES 4bpp/8-palette limits and ensure 8x8 tile seams are not visible after conversion.
+- Title and logo backgrounds display immediately at boot; confirm gradients remain banded cleanly.
+- High score and score entry backgrounds host text overlays—confirm readability and that the parchment center tiles without seams.
+- Level complete sets are referenced by the level completion script; confirm banners sit above HUD-safe regions and that palette cycling or tiling stays stable across transitions.

--- a/data/backgrounds/hiscore.gfx_bg/hiscore.gfx_bg.txt
+++ b/data/backgrounds/hiscore.gfx_bg/hiscore.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: High Score Screen
+Target output filename: hiscore.gfx_bg.png
+Resolution: 256x224 SNES background, 4bpp with up to 8 palettes; emphasize large flat panels for clean palette quantization.
+Prompt: "Dragon's Lair inspired castle hall scoreboard, ornate stone arch framing parchment high-score list, Dirk and Princess Daphne crest at the top, warm torchlight glows on stone blocks, medieval scroll texture, 16-bit SNES pixel art look, limited colors, 256x224." 
+Alignment notes: Leave generous vertical padding for score text overlays; keep the parchment center light and low-detail to preserve readability after tiling.

--- a/data/backgrounds/levelcomplete.0.gfx_bg/levelcomplete.0.gfx_bg.txt
+++ b/data/backgrounds/levelcomplete.0.gfx_bg/levelcomplete.0.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: Level Complete (Set A)
+Target output filename: levelcomplete.0.gfx_bg.png
+Resolution: 256x224 SNES background, 4bpp with up to 8 palettes; keep gradients minimal to respect 16-color-per-palette limits.
+Prompt: "Dragon's Lair victory splash, Dirk the Daring standing triumphant with sword raised, treasure chest at his feet, castle corridor backdrop with warm torches, bold 'Stage Cleared' ribbon, 16-bit SNES pixel art, clean color blocks, 256x224." 
+Alignment notes: Keep the focal art centered; leave lower third relatively calm for score banners and avoid tiny decorative fonts that will blur after tile conversion.

--- a/data/backgrounds/levelcomplete.1.gfx_bg/levelcomplete.1.gfx_bg.txt
+++ b/data/backgrounds/levelcomplete.1.gfx_bg/levelcomplete.1.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: Level Complete (Set B)
+Target output filename: levelcomplete.1.gfx_bg.png
+Resolution: 256x224 SNES background, 4bpp with up to 8 palettes; stick to flat shading and avoid dithering beyond 8 palettes.
+Prompt: "Dragon's Lair intermission card, Dirk and Daphne framed by stained glass window, celebratory banner reading 'Quest Advanced', castle interior columns, soft torchlight, 16-bit SNES pixel style, limited color ramps, 256x224." 
+Alignment notes: Keep text near the top center; leave the lower half simple so tiled patterns do not distract from HUD overlays.

--- a/data/backgrounds/levelcomplete.2.gfx_bg/levelcomplete.2.gfx_bg.txt
+++ b/data/backgrounds/levelcomplete.2.gfx_bg/levelcomplete.2.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: Level Complete (Set C)
+Target output filename: levelcomplete.2.gfx_bg.png
+Resolution: 256x224 SNES background, 4bpp with up to 8 palettes. Use bold shapes and limited highlights to preserve palette integrity.
+Prompt: "Dragon's Lair success screen, Dirk escaping the dragon's lair with the glowing treasure, cavern opening behind him, bright exit light rays, triumphant banner reading 'Well Done', 16-bit SNES pixel art, limited palette, 256x224." 
+Alignment notes: Keep the banner high on the frame; reserve the bottom margin for score overlays and avoid heavy gradients that will collapse during tile conversion.

--- a/data/backgrounds/scoreentry.gfx_bg/scoreentry.gfx_bg.txt
+++ b/data/backgrounds/scoreentry.gfx_bg/scoreentry.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: Score Entry
+Target output filename: scoreentry.gfx_bg.png
+Resolution: 256x224 SNES background, 4bpp with up to 8 palettes. Keep the central area low-detail for letter input clarity.
+Prompt: "Dragon's Lair name entry screen, stone tablet with carved alphabet grid, softly glowing candles on either side, Dirk's helmet resting on the corner, medieval parchment texture, 16-bit SNES pixel art, restrained colors, 256x224." 
+Alignment notes: Leave a wide blank center panel for the name grid; keep decorative elements constrained to the borders to avoid tiling artifacts.

--- a/data/backgrounds/titlescreen.gfx_bg/titlescreen.gfx_bg.txt
+++ b/data/backgrounds/titlescreen.gfx_bg/titlescreen.gfx_bg.txt
@@ -1,0 +1,5 @@
+Background: Title Screen
+Target output filename: titlescreen.gfx_bg.png
+Resolution: 256x224 SNES background (8x8 tiles), 4bpp with up to 8 palettes (16 colors each, keep totals under 128 colors). Favor broad, flat color regions to avoid tile breakup.
+Prompt: "Dragon's Lair arcade title screen, Dirk the Daring silhouette with raised sword in front of a stone castle gate, bold 'Dragon's Lair' logotype in glowing magenta and gold, dramatic torchlight, dark vignette edges, crisp 16-bit SNES style, limited color bands, no gradients, 256x224." 
+Alignment notes: Keep the logo horizontally centered; leave safe margins around edges for HUD overlays and palette cycling. Avoid fine text that would muddy after 4bpp quantization.

--- a/src/object/background/abstract.Background.h
+++ b/src/object/background/abstract.Background.h
@@ -73,6 +73,7 @@ BackgroundAnimationLUT:
   PTRLONG BackgroundAnimationLUT BG.hiscore
   PTRLONG BackgroundAnimationLUT BG.scoreentry
   PTRLONG BackgroundAnimationLUT BG.hud
+  PTRLONG BackgroundAnimationLUT BG.levelcomplete.0
   PTRLONG BackgroundAnimationLUT BG.levelcomplete.1
   PTRLONG BackgroundAnimationLUT BG.levelcomplete.2
   
@@ -83,6 +84,7 @@ BackgroundAnimationLUT:
   BG_ANIMATION hiscore gfx_bg
   BG_ANIMATION scoreentry gfx_bg
   BG_ANIMATION hud gfx_directcolor
+  BG_ANIMATION levelcomplete.0 gfx_bg
   BG_ANIMATION levelcomplete.1 gfx_bg
-  BG_ANIMATION levelcomplete.2 gfx_bg  
+  BG_ANIMATION levelcomplete.2 gfx_bg
 


### PR DESCRIPTION
## Summary
- document background assets and mark RoadBlaster captures for Dragon's Lair replacements, with palette and workflow notes
- add per-background `.gfx_bg.txt` prompt stubs describing required resolution, palette limits, and layout constraints
- register the levelcomplete.0 background animation so newly generated art will be included by the build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920056cda448325baab91a1e0eb9642)