### PR TITLE
Add Lua scene exporter test coverage and documentation

### DIFF
--- a/tests/fixtures/lua_scene_exporter/expected_chapter.script
+++ b/tests/fixtures/lua_scene_exporter/expected_chapter.script
@@ -1,0 +1,20 @@
+# chapter.script generated from Lua scenes
+scene sample_scene
+  sequence fail
+    start_time: 1600
+    end_time: 1700
+    is_single_frame: False
+
+  sequence start_alive
+    start_time: 100
+    end_time: 400
+    timeout: when=800 next=fail
+    is_single_frame: False
+    actions:
+      - input=left from=150 to=300 next=success interrupt=jump
+      - input=right from=200 to=350 next=fail interrupt=duck
+
+  sequence success
+    start_time: 1200
+    end_time: 1300
+    is_single_frame: True

--- a/tests/fixtures/lua_scene_exporter/game.lua
+++ b/tests/fixtures/lua_scene_exporter/game.lua
@@ -1,0 +1,23 @@
+-- Trimmed-down sample covering time windows, timeouts, actions, and single-frame flags.
+scenes = {
+    sample_scene = {
+        start_alive = {
+            start_time = 100,
+            end_time = 400,
+            timeout = { when = 800, nextsequence = "fail" },
+            actions = {
+                { input = "left", from = 150, to = 300, interrupt = "jump", nextsequence = "success" },
+                { input = "right", from = 200, to = 350, interrupt = "duck", nextsequence = "fail" },
+            },
+        },
+        success = {
+            start_time = 1200,
+            end_time = 1300,
+            is_single_frame = true,
+        },
+        fail = {
+            start_time = 1600,
+            end_time = 1700,
+        },
+    },
+}

--- a/tests/test_lua_scene_exporter.py
+++ b/tests/test_lua_scene_exporter.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TOOLS = ROOT / "tools"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "lua_scene_exporter"
+
+
+def run_exporter(lua_file: Path, output_path: Path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS / "lua_scene_exporter.py"),
+            "--input",
+            str(lua_file),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_lua_scene_exporter(tmp_path):
+    lua_file = FIXTURE_DIR / "game.lua"
+    expected_script = (FIXTURE_DIR / "expected_chapter.script").read_text()
+
+    output_path = tmp_path / "chapter.script"
+    run_exporter(lua_file, output_path)
+
+    assert output_path.exists()
+    assert output_path.read_text() == expected_script

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,6 +15,7 @@ This folder contains the helper utilities used to prepare assets and builds for 
 | `snes_convert.py` | Simple helper to letterbox and palette-reduce PNGs to SNES-friendly dimensions and color counts. | PNG input. | Palette-indexed PNG at 256×224. | Quick background mockups before full tile conversion.
 | `userOptions.py` | Lightweight command-line option parser used by other scripts. | CLI arguments. | Sanitized option dictionary. | Shared helper for Python tooling.
 | `xmlsceneparser.py` | Parses Dragon's Lair iPhone XML to emit scene event lists, frame folders, and audio references. | iPhone XML descriptor plus video/audio paths. | Extracted frame/audio listings written to folders. | Driving chapter/frame extraction ahead of tile conversion and MSU packaging.
+| `lua_scene_exporter.py` | Converts DirkSimple-style `game.lua` scene tables into readable chapter scripts for regression tests. | Trimmed `game.lua` inputs containing `scenes` tables. | Textual `chapter.script` summaries listing sequences, actions, and timeouts. | Validating scene metadata before running full conversion.
 | `snesbrr-2006-12-13/` | BRR encoder/decoder for SNES samples with loop handling. | WAV PCM audio. | BRR sample blocks or decoded WAV. | Building SPC sound effects or MOD sample banks.
 | `wla-dx-9.5-svn/` | Cross-platform macro assembler/linker suite for 65816/SPC700 and related CPUs. | Assembly source, object/library files. | Object files, linked ROM/SRAM binaries. | Main code build toolchain for SNES ROM and SPC binaries.
 
@@ -99,6 +100,11 @@ This folder contains the helper utilities used to prepare assets and builds for 
 * **Purpose:** Parse Dragon’s Lair iPhone XML descriptors and emit frame/audio listings per chapter, creating output folders for subsequent conversion.
 * **Inputs/Outputs:** XML scene definition and related media paths; writes scene event lists and organizes frame/audio references in folders.
 * **Pipeline:** Early extraction step before running image converters and MSU1 packers.
+
+### lua_scene_exporter.py
+* **Purpose:** Read DirkSimple-style `game.lua` scene tables and write a readable `chapter.script` summary that captures timings, timeouts, actions, and single-frame markers.
+* **Inputs/Outputs:** `game.lua` input; writes `chapter.script` text to the requested destination path.
+* **Tests:** `python -m pytest tests/test_lua_scene_exporter.py`
 
 ### snesbrr-2006-12-13
 * **Purpose:** Standalone SNES BRR encoder/decoder supporting loop points and optional Gaussian filtering.

--- a/tools/lua_scene_exporter.py
+++ b/tools/lua_scene_exporter.py
@@ -1,0 +1,199 @@
+"""Extract simplified Dragon's Lair scene timing data from game.lua.
+
+This exporter is intentionally limited to the subset of the DirkSimple
+`game.lua` format used in tests. It reads the `scenes` table and emits a
+textual `chapter.script` summary that preserves start/end times,
+timeouts, actions, and single-frame flags.
+"""
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any, List, Tuple, Union
+
+Token = Union[str, int, bool, None, Tuple[str, str]]
+
+
+def strip_comments(text: str) -> str:
+    """Remove Lua single-line comments."""
+    return "\n".join(line.split("--", 1)[0] for line in text.splitlines())
+
+
+def tokenize(content: str) -> List[Token]:
+    tokens: List[Token] = []
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if ch.isspace():
+            i += 1
+            continue
+
+        if ch in "{}=,":
+            tokens.append(ch)
+            i += 1
+            continue
+
+        if ch == '"':
+            j = i + 1
+            value_chars: List[str] = []
+            while j < len(content):
+                if content[j] == "\\":
+                    if j + 1 < len(content):
+                        value_chars.append(content[j + 1])
+                        j += 2
+                        continue
+                if content[j] == '"':
+                    break
+                value_chars.append(content[j])
+                j += 1
+            tokens.append("".join(value_chars))
+            i = j + 1
+            continue
+
+        if ch.isdigit() or (ch == "-" and i + 1 < len(content) and content[i + 1].isdigit()):
+            j = i + 1
+            while j < len(content) and content[j].isdigit():
+                j += 1
+            tokens.append(int(content[i:j]))
+            i = j
+            continue
+
+        if ch.isalpha() or ch == "_":
+            j = i + 1
+            while j < len(content) and (content[j].isalnum() or content[j] == "_"):
+                j += 1
+            ident = content[i:j]
+            if ident == "true":
+                tokens.append(True)
+            elif ident == "false":
+                tokens.append(False)
+            elif ident == "nil":
+                tokens.append(None)
+            else:
+                tokens.append(("IDENT", ident))
+            i = j
+            continue
+
+        # Skip unrecognized characters to keep parsing tolerant for the test subset.
+        i += 1
+
+    return tokens
+
+
+def parse_value(tokens: List[Token], position: int) -> Tuple[Any, int]:
+    tok = tokens[position]
+    if tok == "{":
+        return parse_table(tokens, position)
+    if isinstance(tok, tuple) and tok[0] == "IDENT":
+        return tok[1], position + 1
+    return tok, position + 1
+
+
+def parse_table(tokens: List[Token], position: int) -> Tuple[Any, int]:
+    assert tokens[position] == "{"
+    position += 1
+    entries: List[Any] = []
+    keyed = False
+
+    while position < len(tokens) and tokens[position] != "}":
+        if tokens[position] == ",":
+            position += 1
+            continue
+
+        if position + 1 < len(tokens) and tokens[position + 1] == "=":
+            key_token = tokens[position]
+            key = key_token[1] if isinstance(key_token, tuple) else key_token
+            position += 2
+            value, position = parse_value(tokens, position)
+            entries.append((key, value))
+            keyed = True
+        else:
+            value, position = parse_value(tokens, position)
+            entries.append(value)
+
+        if position < len(tokens) and tokens[position] == ",":
+            position += 1
+
+    position += 1  # consume closing brace
+
+    if keyed:
+        table: dict[str, Any] = {}
+        for entry in entries:
+            if isinstance(entry, tuple) and len(entry) == 2:
+                key, value = entry
+                table[str(key)] = value
+        return table, position
+
+    return entries, position
+
+
+def parse_scenes(lua_text: str) -> dict:
+    cleaned = strip_comments(lua_text)
+    match = re.search(r"scenes\s*=\s*{", cleaned)
+    if not match:
+        raise ValueError("Could not locate scenes table in Lua source")
+
+    start = match.start()
+    brace_start = cleaned.find("{", start)
+    tokens = tokenize(cleaned[brace_start:])
+    scenes, _ = parse_table(tokens, 0)
+    if not isinstance(scenes, dict):
+        raise ValueError("Scenes table did not parse into a dictionary")
+    return scenes
+
+
+def format_chapter_script(scenes: dict) -> str:
+    lines: List[str] = ["# chapter.script generated from Lua scenes"]
+    for scene_name in sorted(scenes.keys()):
+        lines.append(f"scene {scene_name}")
+        sequences = scenes[scene_name]
+        if not isinstance(sequences, dict):
+            continue
+        for sequence_name in sorted(sequences.keys()):
+            sequence = sequences[sequence_name]
+            lines.append(f"  sequence {sequence_name}")
+            start_time = sequence.get("start_time")
+            lines.append(f"    start_time: {start_time}")
+            if "end_time" in sequence:
+                lines.append(f"    end_time: {sequence.get('end_time')}")
+
+            timeout = sequence.get("timeout")
+            if isinstance(timeout, dict):
+                when = timeout.get("when")
+                next_sequence = timeout.get("nextsequence")
+                lines.append(f"    timeout: when={when} next={next_sequence}")
+
+            lines.append(f"    is_single_frame: {bool(sequence.get('is_single_frame', False))}")
+
+            actions = sequence.get("actions") or []
+            if actions:
+                lines.append("    actions:")
+                for action in actions:
+                    lines.append(
+                        "      - input={input} from={from_time} to={to_time} next={next_seq} interrupt={interrupt}".format(
+                            input=action.get("input"),
+                            from_time=action.get("from"),
+                            to_time=action.get("to"),
+                            next_seq=action.get("nextsequence"),
+                            interrupt=action.get("interrupt"),
+                        )
+                    )
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export chapter.script summary from a Lua scenes file")
+    parser.add_argument("--input", required=True, help="Path to game.lua source")
+    parser.add_argument("--output", required=True, help="Destination path for chapter.script")
+    args = parser.parse_args()
+
+    lua_text = Path(args.input).read_text()
+    scenes = parse_scenes(lua_text)
+    output_text = format_chapter_script(scenes)
+    Path(args.output).write_text(output_text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lua_scene_exporter helper to turn trimmed DirkSimple game.lua files into chapter.script summaries
- add a fixture and golden output plus a pytest that exercises the exporter
- document the new tool and the test command in tools/README

## Testing
- python -m pytest tests/test_lua_scene_exporter.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692022bf73ac8325a4a133e65c0f8d33)