### PR TITLE
Add Lua-to-XML converter for scene chapters

### DIFF
--- a/data/events/README.md
+++ b/data/events/README.md
@@ -1,0 +1,30 @@
+# Event XML Reference
+
+This directory contains the per-chapter XML descriptors that drive the original RoadBlaster/Dragon's Lair asset pipeline. Each file mirrors the format produced by the classic iPhone XML scene dumps so the legacy tooling (for example, `xmlsceneparser.py` and the frame/audio extraction steps) can recreate chapters or alternate XMLs without guessing at tag semantics.
+
+## Chapter layout
+- **Root `<chapter>`**: Optional `name` attribute; otherwise the filename defines the chapter name.
+- **`<timeline>`**: Required start/end bounds for the clip. Times are split into `min`, `second`, and `ms` attributes so they can be mapped directly to frame counts when chopping source video.
+- **`<params>`**: Key/value pairs that configure how the engine should treat the clip (for example, `controller`, `cockpit`, `level`, debug switches). Keys are stored as `<int>` or `<str>` tags with `key`/`value` attributes.
+- **`<macros>`**: Optional macro overrides scoped to the chapter; when present they shadow any global macros loaded elsewhere in the pipeline.
+- **`<events>`**: Input windows and helpers that occur between `timestart` and `timeend`. Common event types include:
+  - `checkpoint`: Marks respawn points; usually paired with the chapter entry timestamp.
+  - `direction`: Records required controller direction (`type`), score reward, and failure branch via `<result>`.
+  - `confirm`: Waits for a start/confirm input before branching to another chapter.
+  - `hide-dash`: UI helper to hide the HUD during prerendered sequences.
+  - Other game-specific helpers follow the same structure: a `<timeline>`, optional `<params>`, and one or more `<result>` branches chosen by `value`.
+- **`<result>`**: Defines the chapter that should play next when the chapter finishes or when an event branch is taken. Branches use `<playchapter name="..."/>` to jump forward; a single `<result>` outside of `<events>` acts as the default completion path.
+
+## Timing conventions
+- All `timestart`/`timeend` elements use **minute/second/millisecond** attributes instead of absolute frame counts. The original conversion scripts multiply these into frame indexes using the clip FPS (23.9777 in `xmlsceneparser.py`).
+- Individual events often re-state their own `<timeline>` window inside the chapter range so the tooling can trim per-input snippets or build MSU-1 frame folders with matching offsets.
+
+## Recreating alternate XMLs
+1. Export or hand-author XMLs in this layout for each chapter you want to feed into the RoadBlaster conversion tools.
+2. Run `xmlsceneparser.py` with the XML file, output folder, and optional video/audio inputs. It will:
+   - Generate `chapter.script`/`chapter.include` references.
+   - Slice frames/audio for the chapter when media is provided.
+   - Copy any already-converted frame binaries if you point `convertedoutfolder`/`convertedframefolder` at an existing build.
+3. Feed the extracted frames into the usual `gracon.py` → `animationWriter.py`/`msu1blockwriter.py` pipeline.
+
+This documentation should be enough to rebuild the Dragon's Lair event XMLs—or author new ones—using the original RoadBlaster tooling without needing to reverse-engineer the individual files.

--- a/tools/game_lua_to_json.py
+++ b/tools/game_lua_to_json.py
@@ -1,0 +1,283 @@
+"""Convert the DirkSimple `game.lua` scenes table into JSON.
+
+This parser evaluates the helper timing functions used in `tools/game.lua`
+(`time_to_ms`, `time_laserdisc_frame`, etc.) and expands the full `scenes`
+table into plain Python data before serializing it as JSON. Use it to inspect
+or feed the Dragon's Lair scene timings into other pipelines without pulling
+in a Lua runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple, Union
+
+Token = Union[str, int, float, bool, None, Tuple[str, str]]
+
+
+# Timing helpers mirrored from tools/game.lua
+# Laserdisc frame rate for the Dragon's Lair source.
+FRAME_RATE = 23.976
+
+
+def laserdisc_frame_to_ms(frame: float) -> float:
+    return (frame / FRAME_RATE) * 1000.0
+
+
+def time_laserdisc_frame(frame: float) -> float:
+    return laserdisc_frame_to_ms(frame) - 6297.0
+
+
+def time_laserdisc_noseek() -> int:
+    return -1
+
+
+def time_to_ms(*parts: float) -> float:
+    if len(parts) == 2:
+        seconds, milliseconds = parts
+        return (seconds * 1000.0) + milliseconds
+    if len(parts) == 3:
+        minutes, seconds, milliseconds = parts
+        return ((minutes * 60.0) + seconds) * 1000.0 + milliseconds
+    raise ValueError(f"Unsupported time_to_ms arity: {len(parts)}")
+
+
+FUNCTIONS: Dict[str, Callable[..., Any]] = {
+    "laserdisc_frame_to_ms": laserdisc_frame_to_ms,
+    "time_laserdisc_frame": time_laserdisc_frame,
+    "time_laserdisc_noseek": time_laserdisc_noseek,
+    "time_to_ms": time_to_ms,
+}
+
+
+@dataclass
+class ParserState:
+    tokens: List[Token]
+    position: int = 0
+
+    def current(self) -> Token:
+        return self.tokens[self.position]
+
+    def advance(self) -> None:
+        self.position += 1
+
+    def expect(self, value: Token) -> None:
+        if self.current() != value:
+            raise ValueError(
+                f"Expected token {value!r} at position {self.position}, found {self.current()!r}"
+            )
+        self.advance()
+
+
+# Lexing
+
+
+def strip_comments(text: str) -> str:
+    return "\n".join(line.split("--", 1)[0] for line in text.splitlines())
+
+
+def tokenize(content: str) -> List[Token]:
+    tokens: List[Token] = []
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if ch.isspace():
+            i += 1
+            continue
+
+        if ch in "{}=,()+-":
+            tokens.append(ch)
+            i += 1
+            continue
+
+        if ch == '"':
+            j = i + 1
+            value_chars: List[str] = []
+            while j < len(content):
+                if content[j] == "\\":
+                    if j + 1 < len(content):
+                        value_chars.append(content[j + 1])
+                        j += 2
+                        continue
+                if content[j] == '"':
+                    break
+                value_chars.append(content[j])
+                j += 1
+            tokens.append("".join(value_chars))
+            i = j + 1
+            continue
+
+        if ch.isdigit() or (ch == "-" and i + 1 < len(content) and content[i + 1].isdigit()):
+            j = i + 1
+            has_dot = False
+            while j < len(content):
+                if content[j].isdigit():
+                    j += 1
+                    continue
+                if content[j] == "." and not has_dot:
+                    has_dot = True
+                    j += 1
+                    continue
+                break
+            number_str = content[i:j]
+            tokens.append(float(number_str) if "." in number_str else int(number_str))
+            i = j
+            continue
+
+        if ch.isalpha() or ch == "_":
+            j = i + 1
+            while j < len(content) and (content[j].isalnum() or content[j] == "_"):
+                j += 1
+            ident = content[i:j]
+            if ident == "true":
+                tokens.append(True)
+            elif ident == "false":
+                tokens.append(False)
+            elif ident == "nil":
+                tokens.append(None)
+            else:
+                tokens.append(("IDENT", ident))
+            i = j
+            continue
+
+        i += 1  # skip anything unrecognized
+
+    return tokens
+
+
+# Parsing
+
+
+def parse_value(state: ParserState) -> Any:
+    tok = state.current()
+
+    if tok == "{":
+        return parse_table(state)
+    if tok == "(":
+        state.advance()
+        value = parse_expression(state)
+        state.expect(")")
+        return value
+    if tok == "-":
+        state.advance()
+        return -parse_value(state)
+    if isinstance(tok, tuple) and tok[0] == "IDENT":
+        return parse_identifier_or_call(state)
+
+    state.advance()
+    return tok
+
+
+def parse_identifier_or_call(state: ParserState) -> Any:
+    ident = state.current()
+    assert isinstance(ident, tuple) and ident[0] == "IDENT"
+    name = ident[1]
+    state.advance()
+
+    if state.position < len(state.tokens) and state.current() == "(":
+        state.advance()
+        args: List[Any] = []
+        while state.position < len(state.tokens) and state.current() != ")":
+            args.append(parse_expression(state))
+            if state.current() == ",":
+                state.advance()
+        state.expect(")")
+        func = FUNCTIONS.get(name)
+        if func is None:
+            return {"function": name, "args": args}
+        return func(*args)
+
+    return name
+
+
+def parse_expression(state: ParserState) -> Any:
+    value = parse_term(state)
+    while state.position < len(state.tokens) and state.current() in {"+", "-"}:
+        op = state.current()
+        state.advance()
+        rhs = parse_term(state)
+        if not isinstance(value, (int, float)) or not isinstance(rhs, (int, float)):
+            raise ValueError(
+                f"Cannot apply operator {op!r} to non-numeric values: {value!r}, {rhs!r}"
+            )
+        value = value + rhs if op == "+" else value - rhs
+    return value
+
+
+def parse_term(state: ParserState) -> Any:
+    return parse_value(state)
+
+
+def parse_table(state: ParserState) -> Any:
+    state.expect("{")
+    entries: List[Any] = []
+    keyed = False
+
+    while state.position < len(state.tokens) and state.current() != "}":
+        if state.current() == ",":
+            state.advance()
+            continue
+
+        if (state.position + 1 < len(state.tokens)) and (state.tokens[state.position + 1] == "="):
+            key_token = state.current()
+            key = key_token[1] if isinstance(key_token, tuple) else key_token
+            state.advance()  # key
+            state.advance()  # equals
+            value = parse_expression(state)
+            entries.append((key, value))
+            keyed = True
+        else:
+            entries.append(parse_expression(state))
+
+        if state.position < len(state.tokens) and state.current() == ",":
+            state.advance()
+
+    state.expect("}")
+
+    if keyed:
+        table: Dict[str, Any] = {}
+        for entry in entries:
+            if isinstance(entry, tuple) and len(entry) == 2:
+                key, value = entry
+                table[str(key)] = value
+        return table
+
+    return entries
+
+
+# Driver
+
+
+def parse_scenes(lua_text: str) -> Dict[str, Any]:
+    cleaned = strip_comments(lua_text)
+    match = re.search(r"scenes\s*=\s*{", cleaned)
+    if not match:
+        raise ValueError("Could not locate scenes table in Lua source")
+
+    brace_start = cleaned.find("{", match.start())
+    tokens = tokenize(cleaned[brace_start:])
+    state = ParserState(tokens)
+    scenes = parse_table(state)
+    if not isinstance(scenes, dict):
+        raise ValueError("Scenes table did not parse into a dictionary")
+    return scenes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Expand tools/game.lua scenes into JSON")
+    parser.add_argument("--input", default="tools/game.lua", help="Path to the game.lua source")
+    parser.add_argument("--output", required=True, help="Destination JSON path")
+    parser.add_argument("--indent", type=int, default=2, help="Indent level for JSON output")
+    args = parser.parse_args()
+
+    lua_text = Path(args.input).read_text()
+    scenes = parse_scenes(lua_text)
+    Path(args.output).write_text(json.dumps(scenes, indent=args.indent, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/game_lua_to_xml.py
+++ b/tools/game_lua_to_xml.py
@@ -1,0 +1,224 @@
+"""Convert DirkSimple game.lua scenes into per-sequence XML chapters.
+
+This script mirrors the timing helpers in ``tools/game.lua`` and reuses the
+Lua parser from ``game_lua_to_json.py`` to expand the ``scenes`` table. Each
+sequence becomes a chapter XML that follows ``data/events/README.md`` so it can
+feed the original RoadBlaster/Dragon's Lair conversion tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+import xml.etree.ElementTree as ET
+
+from game_lua_to_json import parse_scenes
+
+# Timing helpers duplicated from tools/game.lua
+FRAME_RATE = 23.976
+
+
+def laserdisc_frame_to_ms(frame: float) -> float:
+    return (frame / FRAME_RATE) * 1000.0
+
+
+def time_laserdisc_frame(frame: float) -> float:
+    return laserdisc_frame_to_ms(frame) - 6297.0
+
+
+def time_laserdisc_noseek() -> int:
+    return -1
+
+
+def time_to_ms(*parts: float) -> float:
+    if len(parts) == 2:
+        seconds, milliseconds = parts
+        return (seconds * 1000.0) + milliseconds
+    if len(parts) == 3:
+        minutes, seconds, milliseconds = parts
+        return ((minutes * 60.0) + seconds) * 1000.0 + milliseconds
+    raise ValueError(f"Unsupported time_to_ms arity: {len(parts)}")
+
+
+TimingFnMap = {
+    "laserdisc_frame_to_ms": laserdisc_frame_to_ms,
+    "time_laserdisc_frame": time_laserdisc_frame,
+    "time_laserdisc_noseek": time_laserdisc_noseek,
+    "time_to_ms": time_to_ms,
+}
+
+
+# XML helpers
+
+def ms_to_parts(ms: float) -> Tuple[int, int, int]:
+    if ms < 0:
+        ms = 0
+    total_ms = int(round(ms))
+    minutes, remainder = divmod(total_ms, 60_000)
+    seconds, milliseconds = divmod(remainder, 1000)
+    return minutes, seconds, milliseconds
+
+
+def append_timeline(parent: ET.Element, start_ms: float, end_ms: Optional[float] = None) -> None:
+    timeline = ET.SubElement(parent, "timeline")
+    min_start, sec_start, ms_start = ms_to_parts(start_ms)
+    ET.SubElement(
+        timeline,
+        "timestart",
+        {
+            "min": str(min_start),
+            "second": str(sec_start),
+            "ms": str(ms_start),
+        },
+    )
+    if end_ms is not None:
+        min_end, sec_end, ms_end = ms_to_parts(end_ms)
+        ET.SubElement(
+            timeline,
+            "timeend",
+            {
+                "min": str(min_end),
+                "second": str(sec_end),
+                "ms": str(ms_end),
+            },
+        )
+
+
+def add_params(parent: ET.Element, params: Mapping[str, object]) -> None:
+    params_elem = ET.SubElement(parent, "params")
+    for key, value in params.items():
+        if isinstance(value, bool):
+            value_int = 1 if value else 0
+            ET.SubElement(params_elem, "int", {"key": key, "value": str(value_int)})
+        elif isinstance(value, (int, float)):
+            ET.SubElement(params_elem, "int", {"key": key, "value": str(int(value))})
+        else:
+            ET.SubElement(params_elem, "str", {"key": key, "value": str(value)})
+
+
+def indent(elem: ET.Element, level: int = 0) -> None:
+    """Pretty-print helper for ElementTree (Python 3.8 compatible)."""
+
+    indent_str = "\n" + (level * "\t")
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = indent_str + "\t"
+        for child in elem:
+            indent(child, level + 1)
+        if not child.tail or not child.tail.strip():  # type: ignore[name-defined]
+            child.tail = indent_str
+    if level and (not elem.tail or not elem.tail.strip()):
+        elem.tail = indent_str
+
+
+# Conversion logic
+
+def chapter_name(scene: str, sequence: str) -> str:
+    return f"{scene}_{sequence}"
+
+
+def resolve_next(scene: str, sequences: Iterable[str], destination: Optional[object]) -> Optional[str]:
+    if not isinstance(destination, str):
+        return None
+    if destination in sequences:
+        return chapter_name(scene, destination)
+    return destination
+
+
+def build_chapter(scene: str, sequence: str, data: MutableMapping[str, object], known_sequences: Iterable[str]) -> ET.Element:
+    start_time = float(data.get("start_time", 0))
+    timeout = data.get("timeout", {}) or {}
+    assert isinstance(timeout, Mapping)
+    duration = float(timeout.get("when", 0))
+    end_time = start_time + duration if duration else start_time
+
+    chapter = ET.Element("chapter", {"name": chapter_name(scene, sequence)})
+    append_timeline(chapter, start_time, end_time)
+
+    params: Dict[str, object] = {}
+    if data.get("kills_player"):
+        params["kills_player"] = 1
+    if params:
+        add_params(chapter, params)
+    else:
+        ET.SubElement(chapter, "params")
+
+    ET.SubElement(chapter, "macros")
+
+    events_elem = ET.SubElement(chapter, "events")
+    # Chapter entry checkpoint
+    checkpoint = ET.SubElement(events_elem, "event", {"type": "checkpoint"})
+    append_timeline(checkpoint, start_time)
+
+    actions = data.get("actions", []) or []
+    if isinstance(actions, list):
+        for index, action in enumerate(actions, start=1):
+            if not isinstance(action, Mapping):
+                continue
+            input_type = action.get("input")
+            if not isinstance(input_type, str):
+                continue
+            action_start = start_time + float(action.get("from", 0))
+            action_end = start_time + float(action.get("to", action.get("from", 0)))
+
+            event = ET.SubElement(
+                events_elem,
+                "event",
+                {
+                    "type": "direction",
+                    "automacro": input_type,
+                    "label": f"action-{index}",
+                },
+            )
+            append_timeline(event, action_start, action_end)
+
+            params_elem = ET.SubElement(event, "params")
+            ET.SubElement(params_elem, "str", {"key": "type", "value": input_type})
+            points = action.get("points")
+            if isinstance(points, (int, float)):
+                ET.SubElement(params_elem, "int", {"key": "score", "value": str(int(points))})
+
+            next_dest = resolve_next(scene, known_sequences, action.get("nextsequence"))
+            if next_dest:
+                result = ET.SubElement(event, "result", {"value": "0"})
+                ET.SubElement(result, "playchapter", {"name": next_dest})
+
+    next_seq = resolve_next(scene, known_sequences, timeout.get("nextsequence"))
+    if next_seq:
+        result = ET.SubElement(chapter, "result")
+        ET.SubElement(result, "playchapter", {"name": next_seq})
+
+    return chapter
+
+
+def write_chapter(path: Path, element: ET.Element) -> None:
+    indent(element)
+    tree = ET.ElementTree(element)
+    path.write_text(ET.tostring(element, encoding="unicode"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert tools/game.lua scenes into XML chapters")
+    parser.add_argument("--input", default="tools/game.lua", help="Path to the game.lua source")
+    parser.add_argument("--output-dir", required=True, help="Directory to write XML chapters")
+    args = parser.parse_args()
+
+    scenes = parse_scenes(Path(args.input).read_text())
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for scene_name, scene_data in scenes.items():
+        if not isinstance(scene_data, Mapping):
+            continue
+        sequences = [name for name in scene_data.keys() if isinstance(name, str)]
+        for sequence_name, sequence_data in scene_data.items():
+            if not isinstance(sequence_data, MutableMapping):
+                continue
+            chapter = build_chapter(scene_name, sequence_name, sequence_data, sequences)
+            write_chapter(output_dir / f"{chapter_name(scene_name, sequence_name)}.xml", chapter)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper that turns tools/game.lua scenes into per-sequence XML chapters compatible with the documented event format
- preserve timing helpers and branching so downstream tools can build alternate Dragon's Lair XMLs

## Testing
- python3 tools/game_lua_to_xml.py --input tools/game.lua --output-dir /tmp/chapters


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c3d5c3548325ae89d10872a4da46)