### PR TITLE
Add sprite prompt descriptions and README overview

### DIFF
--- a/data/sprites/README.md
+++ b/data/sprites/README.md
@@ -1,0 +1,16 @@
+# Sprite prompts overview
+
+The `.gfx_sprite` files in this folder are compiled animation assets referenced by the game's `SpriteAnimationLUT`, so prompt authors can align replacements with in-game usage.
+
+- `left_arrow.gfx_sprite` / `right_arrow.gfx_sprite`: HUD arrows that blink to signal turns.
+- `turbo.gfx_sprite`: HUD callout that pulses when turbo is armed.
+- `brake.gfx_sprite`: HUD warning that flashes when braking is required.
+- `dashboard.gfx_sprite`: HUD dashboard overlay framing gauges without hiding the road.
+- `super.gfx_sprite`: HUD burst effect when the super state is active.
+- `steering_wheel.normal/left/right.gfx_sprite`: Three-frame steering wheel states showing neutral, left lean, and right lean inputs.
+- `life_car.gfx_sprite` / `life_counter.gfx_sprite`: Life icon row and counter that scroll upward after a timer, replacing cars with Dirk head icons.
+- `points.normal.gfx_sprite`: Falling score popup for standard points.
+- `points.extra.gfx_sprite`: Faster falling bonus points popup that precedes the bang burst.
+- `bang.gfx_sprite`: Burst effect that appears after extra bonus points trigger.
+
+Use these notes to craft Dragon's Lair–style visual prompts or replacements that match gameplay context.

--- a/data/sprites/bang.txt
+++ b/data/sprites/bang.txt
@@ -1,0 +1,1 @@
+Dragon's Lair "BANG" burst for bonus hits: comic star-shaped explosion in hot pink and white, popping in with a quick expanding frame then fading sparks.

--- a/data/sprites/brake.txt
+++ b/data/sprites/brake.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD warning labeled "Brake" in crimson with amber backlight, strobing loop when slowing is required without obscuring gauges.

--- a/data/sprites/dashboard.txt
+++ b/data/sprites/dashboard.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD dashboard overlay: sleek metallic panel with neon gauges and indicator lights, subtle looping shimmer while leaving central road view clear.

--- a/data/sprites/left_arrow.txt
+++ b/data/sprites/left_arrow.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD arrow overlay, bright gold outline with red pulse fill, pointing left; looping blink to guide lane change while keeping road visible.

--- a/data/sprites/life_car.txt
+++ b/data/sprites/life_car.txt
@@ -1,0 +1,1 @@
+Dragon's Lair life icon row using Dirk the Daring head instead of car, multiple frames showing decreasing icons that gently scroll upward after a short timer.

--- a/data/sprites/life_counter.txt
+++ b/data/sprites/life_counter.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style life counter with Dirk head tally, frames counting down remaining lives; after a brief delay the strip drifts upward to clear space.

--- a/data/sprites/points.extra.txt
+++ b/data/sprites/points.extra.txt
@@ -1,0 +1,1 @@
+Dragon's Lair bonus score popup: radiant orange numbers with magenta fringe, falling faster than normal points and triggering a follow-up burst effect.

--- a/data/sprites/points.normal.txt
+++ b/data/sprites/points.normal.txt
@@ -1,0 +1,1 @@
+Dragon's Lair falling score popup: glowing yellow numbers dropping from hit enemies, brief sparkle trail and fade-out as they descend.

--- a/data/sprites/right_arrow.txt
+++ b/data/sprites/right_arrow.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD arrow overlay, bright gold outline with red pulse fill, pointing right; looping blink to cue next turn without covering the road.

--- a/data/sprites/steering_wheel.left.txt
+++ b/data/sprites/steering_wheel.left.txt
@@ -1,0 +1,1 @@
+Dragon's Lair steering wheel animation, three frames leaning left with responsive hand turn, rim tilting and shadows shifting to show left input.

--- a/data/sprites/steering_wheel.normal.txt
+++ b/data/sprites/steering_wheel.normal.txt
@@ -1,0 +1,1 @@
+Dragon's Lair steering wheel animation, three-frame loop centered on neutral grip, slight shimmer on chrome rim to show idle wheel awaiting input.

--- a/data/sprites/steering_wheel.right.txt
+++ b/data/sprites/steering_wheel.right.txt
@@ -1,0 +1,1 @@
+Dragon's Lair steering wheel animation, three frames leaning right with confident hand twist, rim tilting and highlights moving to show right input.

--- a/data/sprites/super.txt
+++ b/data/sprites/super.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD burst labeled "SUPER" in radiant gold with violet highlights, looping radiance to signal ultimate power without masking other UI.

--- a/data/sprites/turbo.txt
+++ b/data/sprites/turbo.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD badge reading "Turbo" in electric cyan with orange glow, pulsing loop when boost is armed above the dashboard edge.


### PR DESCRIPTION
## Summary
- add concise Dragon's Lair–style prompt notes next to each sprite asset
- document sprite roles in data/sprites/README.md for prompt authors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e0d54afc8325863a2d620e32dce6)