### PR TITLE
Update arrow prompt descriptions for Dragon's Lair cues

### DIFF
--- a/data/sprites/README.md
+++ b/data/sprites/README.md
@@ -2,7 +2,9 @@
 
 The `.gfx_sprite` files in this folder are compiled animation assets referenced by the game's `SpriteAnimationLUT`, so prompt authors can align replacements with in-game usage.
 
-- `left_arrow.gfx_sprite` / `right_arrow.gfx_sprite`: HUD arrows that blink to signal turns.
+- `left_arrow.gfx_sprite` / `right_arrow.gfx_sprite`: HUD arrows that blink as quick-time cues to dodge hazards or pivot directions, echoing Dragon's Lair reactions.
+- `up_arrow.gfx_sprite`: Upward cue that flashes to prompt leaps onto ledges, grabs onto ropes, or other rising actions.
+- `down_arrow.gfx_sprite`: Downward cue that pulses to signal ducking under blades, sliding away from strikes, or dropping through openings.
 - `turbo.gfx_sprite`: HUD callout that pulses when turbo is armed.
 - `brake.gfx_sprite`: HUD warning that flashes when braking is required.
 - `dashboard.gfx_sprite`: HUD dashboard overlay framing gauges without hiding the road.

--- a/data/sprites/down_arrow.txt
+++ b/data/sprites/down_arrow.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD arrow overlay, bright gold outline with red pulse fill, pointing down; looping flash to cue Dirk to duck under swinging traps, drop through openings, or slide beneath incoming dangers.

--- a/data/sprites/up_arrow.txt
+++ b/data/sprites/up_arrow.txt
@@ -1,0 +1,1 @@
+Dragon's Lair-style HUD arrow overlay, bright gold outline with red pulse fill, pointing up; looping flash to cue Dirk to leap to higher ground, climb onto ropes or ledges, or ride rising platforms.


### PR DESCRIPTION
## Summary
- Reframe the sprite prompt README to describe arrow cues as Dragon's Lair-style quick-time prompts and document vertical cues.
- Add up and down arrow prompt descriptions for jumping, climbing, ducking, and dropping hazards.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e6e5468c832588794c01e8963263)