### PR TITLE
Mark unused racing prompts as non-Dragon's Lair

### DIFF
--- a/data/sprites/README.md
+++ b/data/sprites/README.md
@@ -5,11 +5,11 @@ The `.gfx_sprite` files in this folder are compiled animation assets referenced 
 - `left_arrow.gfx_sprite` / `right_arrow.gfx_sprite`: HUD arrows that blink as quick-time cues to dodge hazards or pivot directions, echoing Dragon's Lair reactions.
 - `up_arrow.gfx_sprite`: Upward cue that flashes to prompt leaps onto ledges, grabs onto ropes, or other rising actions.
 - `down_arrow.gfx_sprite`: Downward cue that pulses to signal ducking under blades, sliding away from strikes, or dropping through openings.
-- `turbo.gfx_sprite`: HUD callout that pulses when turbo is armed.
-- `brake.gfx_sprite`: HUD warning that flashes when braking is required.
+- `turbo.gfx_sprite`: Former racing callout; unused for Dragon's Lair and should be left unreferenced.
+- `brake.gfx_sprite`: Former racing warning; unused for Dragon's Lair and should be left unreferenced.
 - `dashboard.gfx_sprite`: HUD dashboard overlay framing gauges without hiding the road.
 - `super.gfx_sprite`: HUD burst effect when the super state is active.
-- `steering_wheel.normal/left/right.gfx_sprite`: Three-frame steering wheel states showing neutral, left lean, and right lean inputs.
+- `steering_wheel.normal/left/right.gfx_sprite`: Legacy racing wheel trio that is not required for Dragon's Lair scenes; keep unused.
 - `life_car.gfx_sprite` / `life_counter.gfx_sprite`: Life icon row and counter that scroll upward after a timer, replacing cars with Dirk head icons.
 - `points.normal.gfx_sprite`: Falling score popup for standard points.
 - `points.extra.gfx_sprite`: Faster falling bonus points popup that precedes the bang burst.

--- a/data/sprites/brake.txt
+++ b/data/sprites/brake.txt
@@ -1,1 +1,1 @@
-Dragon's Lair-style HUD warning labeled "Brake" in crimson with amber backlight, strobing loop when slowing is required without obscuring gauges.
+Not needed for Dragon's Lair; leave this legacy brake prompt unused so cues stay on-theme.

--- a/data/sprites/steering_wheel.left.txt
+++ b/data/sprites/steering_wheel.left.txt
@@ -1,1 +1,1 @@
-Dragon's Lair steering wheel animation, three frames leaning left with responsive hand turn, rim tilting and shadows shifting to show left input.
+Not needed for Dragon's Lair; leave this legacy steering wheel (left tilt) prompt unused so cues stay on-theme.

--- a/data/sprites/steering_wheel.normal.txt
+++ b/data/sprites/steering_wheel.normal.txt
@@ -1,1 +1,1 @@
-Dragon's Lair steering wheel animation, three-frame loop centered on neutral grip, slight shimmer on chrome rim to show idle wheel awaiting input.
+Not needed for Dragon's Lair; leave this legacy steering wheel (neutral) prompt unused so cues stay on-theme.

--- a/data/sprites/steering_wheel.right.txt
+++ b/data/sprites/steering_wheel.right.txt
@@ -1,1 +1,1 @@
-Dragon's Lair steering wheel animation, three frames leaning right with confident hand twist, rim tilting and highlights moving to show right input.
+Not needed for Dragon's Lair; leave this legacy steering wheel (right tilt) prompt unused so cues stay on-theme.

--- a/data/sprites/turbo.txt
+++ b/data/sprites/turbo.txt
@@ -1,1 +1,1 @@
-Dragon's Lair-style HUD badge reading "Turbo" in electric cyan with orange glow, pulsing loop when boost is armed above the dashboard edge.
+Not needed for Dragon's Lair; leave this legacy turbo prompt unused so cues stay on-theme.


### PR DESCRIPTION
## Summary
- note that turbo, brake, and steering wheel sprites are legacy racing elements not needed for Dragon's Lair
- update their prompt files to instruct leaving them unused to keep the catalog on-theme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e87197b08325af66b865b12baf4e)