### PR TITLE
Update docs for removed RoadBlaster assets

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,10 @@ tools are written in python and not optimized at all.
 Therefore, these files will have to be taken & copied from the regular release of
 the game instead.
 
+Legacy RoadBlaster manifest XMLs and unused helper Python scripts have been removed
+from version control as part of the Dragon's Lair retheme. Use the curated chapter
+XMLs in ./data/events with the remaining toolchain.
+
 
 Requirements to build game ROM:
 -os: linux 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ The game translates the battle-tested RoadBlaster engine into a faithful, MSU-1�
 
 📈 Current Progress
 
-- Scene chapter scripts are staged per encounter in `resources/`, matching the Dragon’s Lair scene list (e.g., `crypt_creeps`, `rolling_balls`, `throne_room`).
+- Chapter XMLs in `data/events/` capture the current Dragon’s Lair scene list (e.g., `crypt_creeps`, `rolling_balls`, `throne_room`).
 - Root engine scripts are now documented with theming guidance in `src/README.md`, including notes to retheme remaining martial-arts SFX on the title screen.
 - Chapter event coverage has been inventoried across 40 scenes; 352 unique event types are referenced, with 14 implemented and 351 still needing object handlers.
 
 🧭 Documentation Map
 
 - `src/README.md` – High-level tour of the boot/title/score/MSU1 scripts plus theming expectations.
+- `data/events/README.md` – Overview of the curated Dragon’s Lair chapter XMLs now tracked in this repo.
 - `data/chapter_event_inventory.md` – Chapter-by-chapter event coverage and gaps to implement in the engine.
 - `tools/README.md` – Python 2.7 tooling notes and converter usage (image, tile, XML, PCM).
 
@@ -39,9 +40,9 @@ We test against both real hardware and accurate emulators.
 📁 Repository Structure
 
 - `src/` – 65816 assembly source (core engine, scene tables, logic).
-- `data/` – Backgrounds, HUD assets, audio, and other converted data. See `data/backgrounds/README.md` for the current audit of RoadBlaster placeholders.
-- `resources/` – Extracted scene scripts organized per Dragon’s Lair encounter (inputs for converters).
-- `tools/` – Utilities for converting images, tiles, maps, audio, XML -> binary.
+- `data/` – Backgrounds, HUD assets, audio, chapter XMLs, and other converted data. See `data/backgrounds/README.md` for the current audit of RoadBlaster placeholders.
+- `data/events/` – Dragon’s Lair chapter XML descriptors used by the toolchain (legacy RoadBlaster XMLs have been removed).
+- `tools/` – Utilities for converting images, tiles, maps, audio, XML -> binary (extraneous helper scripts have been trimmed).
 - `tests/` – ROM tests and automated validation.
 - `makefile` – Full build pipeline (ROM + MSU1).
 - `README.md` – You’re reading it.
@@ -68,7 +69,7 @@ Extract Dragon’s Lair arcade assets
 
 Convert assets into SNES formats using tools in /tools
 
-Replace RoadBlaster data files in /data/
+Replace RoadBlaster data files in /data/ (legacy RoadBlaster XMLs and unused helper scripts have already been removed)
 
 Regenerate scene tables (xml2bin)
 

--- a/data/events/README.md
+++ b/data/events/README.md
@@ -1,18 +1,10 @@
-# Generated DirkSimple event XMLs
+# Dragon's Lair chapter XMLs
 
-This directory contains XML chapters produced from `tools/game.lua` using the Lua-to-XML converter in `tools/game_lua_to_xml.py`. The files mirror the DirkSimple scene table so the SNES pipeline can ingest the same branching and timing data that `game.lua` uses at runtime.
+This directory now tracks the curated Dragon's Lair chapter XMLs used by the SNES toolchain. The legacy RoadBlaster iPhone XML dumps and the auxiliary Lua-to-XML generator scripts were removed to avoid confusion; the files checked in here are the authoritative descriptors consumed by the conversion tools.
 
-## Regenerating
-Run the converter to rebuild the XML set after editing `game.lua`:
-
-```
-python3 tools/game_lua_to_xml.py --input tools/game.lua --output-dir data/events
-```
-
-Each sequence in the `scenes` table becomes a `<chapter>` file named `scene_sequence.xml` with the timing windows, checkpoints, and branching destinations defined in the Lua source.
 # Event XML Reference
 
-This directory contains the per-chapter XML descriptors that drive the original RoadBlaster/Dragon's Lair asset pipeline. Each file mirrors the format produced by the classic iPhone XML scene dumps so the legacy tooling (for example, `xmlsceneparser.py` and the frame/audio extraction steps) can recreate chapters or alternate XMLs without guessing at tag semantics.
+Each file mirrors the format produced by the classic iPhone XML scene dumps so the legacy tooling (for example, `xmlsceneparser.py` and the frame/audio extraction steps) can recreate chapters or alternate XMLs without guessing at tag semantics.
 
 ## Chapter layout
 - **Root `<chapter>`**: Optional `name` attribute; otherwise the filename defines the chapter name.
@@ -32,11 +24,11 @@ This directory contains the per-chapter XML descriptors that drive the original 
 - Individual events often re-state their own `<timeline>` window inside the chapter range so the tooling can trim per-input snippets or build MSU-1 frame folders with matching offsets.
 
 ## Recreating alternate XMLs
-1. Export or hand-author XMLs in this layout for each chapter you want to feed into the RoadBlaster conversion tools.
+1. Export or hand-author XMLs in this layout for each chapter you want to feed into the conversion tools.
 2. Run `xmlsceneparser.py` with the XML file, output folder, and optional video/audio inputs. It will:
    - Generate `chapter.script`/`chapter.include` references.
    - Slice frames/audio for the chapter when media is provided.
    - Copy any already-converted frame binaries if you point `convertedoutfolder`/`convertedframefolder` at an existing build.
 3. Feed the extracted frames into the usual `gracon.py` → `animationWriter.py`/`msu1blockwriter.py` pipeline.
 
-This documentation should be enough to rebuild the Dragon's Lair event XMLs—or author new ones—using the original RoadBlaster tooling without needing to reverse-engineer the individual files.
+This documentation should be enough to rebuild the Dragon's Lair event XMLs—or author new ones—using the original tooling without needing to reverse-engineer the individual files.

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,7 +12,6 @@ This folder contains the helper utilities used to prepare assets and builds for 
 | `mod2snes.py` | Converts ProTracker MOD files into SNES-friendly SPC module format with BRR samples. | `.mod` tracker modules. | `.spcmod` binary plus embedded BRR sample data. | Legacy music path; bypassed when using MSU1 audio.
 | `msu1blockwriter.py` | Packages chapter folders (converted frames, tilemaps, palettes) and chapter audio into MSU1 data and per-chapter PCM files. | Chapter directories containing frame binaries; associated PCM audio per chapter. | MSU1 data file with scene/frame pointers plus chapter `.pcm` audio streams. | Bundling MSU video/audio chapters for playback.
 | `msu1pcmwriter.py` | Validates a WAV file (stereo, 16-bit, 44.1 kHz) and prepends MSU1 PCM headers with optional loop points. | WAV/RIFF PCM audio. | `.pcm` audio with MSU1 header and loop offset. | Preparing MSU1 background music or chapter audio.
-| `snes_convert.py` | Simple helper to letterbox and palette-reduce PNGs to SNES-friendly dimensions and color counts. | PNG input. | Palette-indexed PNG at 256×224. | Quick background mockups before full tile conversion.
 | `userOptions.py` | Lightweight command-line option parser used by other scripts. | CLI arguments. | Sanitized option dictionary. | Shared helper for Python tooling.
 | `xmlsceneparser.py` | Parses Dragon's Lair iPhone XML to emit scene event lists, frame folders, and audio references. | iPhone XML descriptor plus video/audio paths. | Extracted frame/audio listings written to folders. | Driving chapter/frame extraction ahead of tile conversion and MSU packaging.
 | `lua_scene_exporter.py` | Converts DirkSimple-style `game.lua` scene tables into readable chapter scripts for regression tests. | Trimmed `game.lua` inputs containing `scenes` tables. | Textual `chapter.script` summaries listing sequences, actions, and timeouts. | Validating scene metadata before running full conversion.
@@ -82,15 +81,6 @@ This folder contains the helper utilities used to prepare assets and builds for 
   ```
 * **Pipeline:** Produces MSU1-ready audio streams for chapters or background music.
 
-### snes_convert.py
-* **Purpose:** Quick helper to letterbox arbitrary PNGs to 256×224 and quantize them to a specified palette size using nearest-neighbor scaling.
-* **Inputs/Outputs:** PNG input; indexed PNG output.
-* **Example:**
-  ```bash
-  python3 snes_convert.py art/mockup.png build/mockup-indexed.png --colors 48
-  ```
-* **Pipeline:** Fast preview of how backgrounds will quantize before running `gracon.py` for full tile extraction.
-
 ### userOptions.py
 * **Purpose:** Minimal CLI option parser shared by multiple tools; handles type checking and bounds enforcement for `-option value` pairs.
 * **Inputs/Outputs:** Raw CLI arguments; returns sanitized option values.
@@ -128,7 +118,7 @@ This folder contains the helper utilities used to prepare assets and builds for 
 * **Pipeline:** Core build dependency for the game code and any SPC driver binaries.
 
 ## Planned Tool Usage for Dragon’s Lair
-* **Backgrounds:** Use `snes_convert.py` for quick previews, then `gracon.py` (bg mode) to generate tiles, palettes, and tilemaps.
+* **Backgrounds:** Use `gracon.py` (bg mode) to generate tiles, palettes, and tilemaps for final assets; quick-preview helpers like `snes_convert.py` were removed.
 * **Sprites/Animations:** Prepare sprite sheets with `gracon.py` (sprite mode) and package sequences with `animationWriter.py` for VRAM-ready animation files.
 * **Tilemaps:** `gracon.py` emits tilemaps for both backgrounds and sprites; these feed directly into VRAM layout and MSU1 chapter bundles.
 * **MSU1 Audio/Video:** Convert WAV sources with `msu1pcmwriter.py`, organize chapter frames, and package everything via `msu1blockwriter.py`. `xmlsceneparser.py` supplies frame/audio references.
@@ -142,6 +132,9 @@ This folder contains the helper utilities used to prepare assets and builds for 
 * There is no orchestration script that chains `xmlsceneparser.py` → `gracon.py` → `animationWriter.py`/`msu1blockwriter.py`; running conversions still requires manual per-folder commands.
 * Palette limiting across entire chapters (multiple frames sharing palettes) is manual; a batch palette optimizer would prevent redundant palettes during MSU1 packing.
 * Automated regression checks for tilemap limits (size/VRAM budgets) are missing; conversions currently rely on manual inspection.
+
+## Removed helper scripts
+Legacy helpers that were rarely used—such as `snes_convert.py` and Lua-to-XML generators—were removed alongside the RoadBlaster XML set. Rely on the remaining converters and chapter XMLs in `data/events/` when preparing assets.
 
 ## Platform Notes
 * Python tooling expects Pillow; if using Python 2.7, ensure compatible versions of Pillow/argparse are installed, or run with Python 3 where scripts already work.


### PR DESCRIPTION
## Summary
- note removal of legacy RoadBlaster XMLs and unused helper scripts in repository docs
- update chapter XML README to reflect the curated Dragon's Lair set now tracked in `data/events`
- refresh tooling guide to drop references to removed helper scripts and highlight the remaining pipeline

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210ea2204c832580e98775caec1aa2)