### PR TITLE
Standardize control prompts and deprecate RoadBlasters inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The game translates the battle-tested RoadBlaster engine into a faithful, MSU-1�
 - Root engine scripts are now documented with theming guidance in `src/README.md`, including notes to retheme remaining martial-arts SFX on the title screen.
 - Chapter event coverage has been inventoried across 40 scenes; 352 unique event types are referenced, with 14 implemented and 351 still needing object handlers.
 
+🎮 Prompt Control Standard
+
+- Directional prompts are bound to the D-pad: left/right stay horizontal, while up corresponds to RoadBlasters’ old **accelerate** cue and down to the **brake** cue.
+- The action/turbo prompt uses button A as the canonical action button; button B should be treated as an incorrect defensive tap when action is expected.
+- The legacy RoadBlasters prompt names `Event.accelerate` and `Event.brake` remain for compatibility but are considered deprecated; use them as up/down inputs until Dragon’s Lair–specific prompt handlers replace them.
+
 🧭 Documentation Map
 
 - `src/README.md` – High-level tour of the boot/title/score/MSU1 scripts plus theming expectations.

--- a/src/object/event/Event.accelerate.65816
+++ b/src/object/event/Event.accelerate.65816
@@ -1,6 +1,7 @@
 /**
-* Dirk's primary action prompt (sword swing / interact).
-* Uses button A; button B counts as an incorrect defensive tap.
+* Dirk's upward dodge/accelerate prompt (D-pad up).
+* RoadBlasters-era name retained for compatibility; prefer the up
+* direction standard over this deprecated event label.
 */
 .include "src/object/event/Event.accelerate.h"
 .section "Event.accelerate"
@@ -27,18 +28,18 @@
   jsr Event.template.waitTimeline
   bcc +
 
-  lda #JOY_BUTTON_B
+  lda #JOY_DIR_DOWN
   jsr Event.template.triggerOnWrongInput
   bcs +
 
   ;kill self if player pressed appropriate button
   ldx #INPUT.DEVICE.ID.0
   jsr core.input.get.press
-  and.w #JOY_BUTTON_A
+  and.w #JOY_DIR_UP
   beq ++
 
       jsr core.input.get.trigger
-      and.w #JOY_BUTTON_A
+      and.w #JOY_DIR_UP
       beq +++
         lda this.age
         cmp #EVENT.BONUS.EXTRA.TIMEOUT

--- a/src/object/event/Event.brake.65816
+++ b/src/object/event/Event.brake.65816
@@ -1,6 +1,7 @@
 /**
-* Dirk's defensive prompt (duck / block / sidestep).
-* Uses button B; button A counts as an incorrect aggressive tap.
+* Dirk's downward brake/duck prompt (D-pad down).
+* RoadBlasters-era name retained for compatibility; prefer the down
+* direction standard over this deprecated event label.
 */
 .include "src/object/event/Event.brake.h"
 .section "Event.brake"
@@ -27,17 +28,17 @@
   jsr Event.template.waitTimeline
   bcc +
 
-  lda #JOY_BUTTON_A
+  lda #JOY_DIR_UP
   jsr Event.template.triggerOnWrongInput
   bcs +
 
   ;kill self if player pressed appropriate button
   ldx #INPUT.DEVICE.ID.0
   jsr core.input.get.press
-  and.w #JOY_BUTTON_B
+  and.w #JOY_DIR_DOWN
   beq ++
       jsr core.input.get.trigger
-      and.w #JOY_BUTTON_B
+      and.w #JOY_DIR_DOWN
       beq +++
         lda this.age
         cmp #EVENT.BONUS.EXTRA.TIMEOUT


### PR DESCRIPTION
## Summary
- align accelerate and brake event handlers to the D-pad up/down standard while flagging their RoadBlasters names as deprecated
- document the prompt control scheme (up/down/left/right plus action) in the root README for chapter-script authors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692111d6be188325b207d42ce1c7ce52)