### PR TITLE
Update README progress inventory counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The game translates the battle-tested RoadBlaster engine into a faithful, MSU-1�
 
 - Chapter XMLs in `data/events/` capture the current Dragon’s Lair scene list (e.g., `crypt_creeps`, `rolling_balls`, `throne_room`).
 - Root engine scripts are now documented with theming guidance in `src/README.md`, including notes to retheme remaining martial-arts SFX on the title screen.
-- Chapter event coverage has been inventoried across 40 scenes; 352 unique event types are referenced, with 14 implemented and 351 still needing object handlers.
+- Chapter event coverage now spans 516 chapters; the inventory calls out 2 unique XML event types, 118 chapter markers, 18 implemented object types, and 95 unmapped markers that still need handlers.
 
 🎮 Prompt Control Standard
 


### PR DESCRIPTION
## Summary
- refresh the README current progress section to match the latest chapter event inventory
- reflect current chapter coverage, event types, markers, and implemented object counts

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921185da424832598f2c20dc0368cf0)