### PR TITLE
Add logo intro transition script

### DIFF
--- a/README
+++ b/README
@@ -252,7 +252,7 @@ Initial program flow:
 
 -after that, control is passed to ./src/msu1.script, which instanciates
   audio interfaces, displays and then passes control
-  to ./src/data/chapters/logo_intro/chapter.script.
+  to ./src/logo_intro.script for the splash transition into the title.
 
 -finally, all further game action is controlled by events in currently
  active chapter scripts, which are located in ./src/data/chapters/ and

--- a/src/README.md
+++ b/src/README.md
@@ -4,11 +4,12 @@ This directory holds the engine- and flow-control scripts that wire the core sta
 
 ## File guide
 - `main.script` bootstraps MSU1 state, loads persisted scores, and spawns the MSU1 management script for later scenes.
+- `msu1.script` uploads the MSU1 sample pack, shows the MSU1 splash background, and transitions to `logo_intro` when the player continues.
+- `logo_intro.script` handles the post-MSU1 splash transition by briefly showing the logo background, fading back to black, and spawning the title sequence.
 - `title_screen.script` builds the title presentation (logo zoom, palette rotation, intro sound effects) and hands off to `level1` after user input and cleanup.
 - `hall_of_fame.script` renders the high-score list, plays the attract-track audio, and waits for user dismissal before returning to the MSU1 intro.
 - `level_complete.script` shows chapter completion text, displays the player's score, and branches to the next level script after user confirmation.
 - `score_entry.script` runs the post-game name entry sequence, persists the high-score table, and returns to the MSU1 intro sequence.
-- `msu1.script` uploads the MSU1 sample pack, shows the MSU1 splash background, and transitions to `logo_intro` when the player continues.
 - `none.script` is a placeholder that currently errors if invoked.
 
 ## Theming and canonical content review

--- a/src/logo_intro.script
+++ b/src/logo_intro.script
@@ -1,0 +1,57 @@
+
+        SCRIPT logo_intro
+.ACCU 16
+.INDEX 16
+
+  .def objLogoBg hashPtr.1
+  .def objBrightness hashPtr.2
+
+  NEW Brightness.CLS.PTR objBrightness
+
+  lda #BRIGHTNESS.NONE
+  CALL Brightness.set.MTD objBrightness
+
+  lda.w #OBJECT.PROPERTIES.isChapter
+  jsr abstract.Iterator.setProperties
+  jsr abstract.Iterator.killOthers
+
+  lda.w #OBJECT.PROPERTIES.isEvent
+  jsr abstract.Iterator.kill.byProperties
+
+  sep #$20
+  lda.b #BGMODE_MODE_1 | BGMODE_PRIORITY_LAYER_3
+  sta.w ScreenMode
+  lda.w MainScreen
+  and.b #(T_BG1_ENABLE | T_BG2_ENABLE | T_BG3_ENABLE | T_BG4_ENABLE) ~$ff
+  sta.w MainScreen
+
+  rep #$31
+
+  NEW Background.generic.CLS.PTR objLogoBg BG.LAYER.0 BG.logo.PTR
+
+  lda #BRIGHTNESS.FULL
+  CALL Brightness.fadeTo.MTD objBrightness
+
+  jsr SavePC
+
+  CALL Brightness.isDone.MTD objBrightness
+  bcs +
+    rts
++
+
+  lda #BRIGHTNESS.NONE
+  CALL Brightness.fadeTo.MTD objBrightness
+
+  jsr SavePC
+  CALL Brightness.isDone.MTD objBrightness
+
+  bcs +
+    rts
++
+
+  CALL Background.generic.kill.MTD objLogoBg
+
+  NEW Script.CLS.PTR oopCreateNoPtr title_screen
+
+  rts
+

--- a/src/object/script/script.h
+++ b/src/object/script/script.h
@@ -39,6 +39,7 @@
 .include "src/main.script"
 .include "src/none.script"
 .include "src/title_screen.script"
+.include "src/logo_intro.script"
 .include "src/hall_of_fame.script"
 .include "src/msu1.script"
 .include "src/score_entry.script"


### PR DESCRIPTION
## Summary
- add a `logo_intro` transition script that fades the logo background between the MSU splash and the title
- include the new script in the script includes so the symbol is emitted during assembly
- update documentation to point to the new path and flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692128196c60832584e762c2d405059a)