### PR TITLE
Add JPEG to PNG converter utility

### DIFF
--- a/tests/test_jpeg_to_png.py
+++ b/tests/test_jpeg_to_png.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+def create_sample_jpeg(path: Path) -> None:
+    image = Image.new("RGB", (4, 4), color=(255, 0, 0))
+    image.save(path, format="JPEG")
+
+
+def test_jpeg_to_png_conversion(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.jpg"
+    output_path = tmp_path / "sample.png"
+    create_sample_jpeg(input_path)
+
+    script_path = Path(__file__).resolve().parents[1] / "tools" / "jpeg_to_png.py"
+
+    subprocess.run(
+        [sys.executable, str(script_path), "--input", str(input_path), "--output", str(output_path), "--colorspace", "RGBA"],
+        check=True,
+    )
+
+    assert output_path.exists(), "PNG output file was not created"
+
+    with Image.open(output_path) as png_image:
+        assert png_image.mode == "RGBA"
+        assert png_image.format == "PNG"

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,6 +10,7 @@ This folder contains the helper utilities used to prepare assets and builds for 
 | `animationWriter.py` | Packs ordered frame images into a custom sprite animation file with tiles, tilemaps, and palettes. | Indexed or true-color frame images (`.png`, `.gif`, `.bmp`) in a folder. | Custom binary animation bundle (`SP` header) containing tile/palette chunks. | Sprite cutscenes and in-game animations.
 | `debugLog.py` | Helper to recursively log nested data structures for debugging. | Python data structures. | Text log output. | Shared helper for the legacy Python tools.
 | `gfx_converter.py` | **NEW** Unified wrapper for `superfamiconv` or `gracon.py` with consistent output naming. | Any Pillow-supported image (PNG, GIF, etc.). | `.palette`, `.tiles`, `.tilemap` binary files. | Replacement for direct `gracon.py` calls; allows swapping converters without changing build scripts.
+| `jpeg_to_png.py` | Converts JPEG images to PNG with optional colorspace normalization and overwrite protection. | `.jpg`, `.jpeg`. | `.png`. | Quick standalone conversion before SNES-specific processing.
 | `gimp-batch-convert-indexed.scm` | GIMP batch script that converts matching images to indexed palettes with Gaussian blur pre-pass. | Any GIMP-loadable images matching a pattern. | In-place indexed images. | Pre-processing art assets before tile conversion when manual palette control is needed.
 | `gracon.py` | Converts images into SNES bitplane graphics, palettes, and tilemaps for backgrounds or sprites with optional deduplication. | Any Pillow-supported image (PNG, GIF, etc.). | Bitplane tile data, palette data, and tilemaps; optional PNG verification. | Core background/sprite converter for RoadBlaster.
 | `img_processor.py` | **NEW** Resizes and crops images to SNES resolutions with color quantization. | Any Pillow-supported image. | Processed PNG at target resolution with optional color reduction. | Pre-processing artwork to 256x224 and reducing to 16 colors before conversion.
@@ -39,6 +40,15 @@ This folder contains the helper utilities used to prepare assets and builds for 
   - `contain`: Resize to fit within dimensions, pad with background color
   - `stretch`: Resize to exact dimensions ignoring aspect ratio
 * **Pipeline:** First step for processing high-resolution artwork before SNES conversion.
+
+### jpeg_to_png.py
+* **Purpose:** Lightweight converter for turning JPEGs into PNGs with optional colorspace normalization (e.g., force RGBA) and overwrite protection.
+* **Inputs/Outputs:** JPEG input; PNG output.
+* **Example:**
+  ```bash
+  python tools/jpeg_to_png.py --input photos/frame.jpg --colorspace RGBA
+  ```
+* **Pipeline:** Quick prep step when you receive JPEG assets but need lossless PNGs before running `img_processor.py` or `gfx_converter.py`.
 
 ### gfx_converter.py
 * **Purpose:** Unified wrapper for `superfamiconv` or `gracon.py` providing consistent output naming (`.palette`, `.tiles`, `.tilemap`).

--- a/tools/jpeg_to_png.py
+++ b/tools/jpeg_to_png.py
@@ -1,0 +1,72 @@
+"""Convert JPEG images to PNG with optional colorspace normalization.
+
+This script provides a small CLI wrapper around Pillow to convert JPEG
+files to PNG, optionally forcing a specific Pillow mode (e.g., RGBA).
+It includes overwrite protection to avoid clobbering existing files.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert a JPEG image to PNG with optional colorspace normalization.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the input JPEG image.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to the output PNG image. Defaults to input basename with .png extension.",
+    )
+    parser.add_argument(
+        "--colorspace",
+        help="Optional Pillow mode to normalize the image to (e.g., RGBA).",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting the output file if it already exists.",
+    )
+    return parser.parse_args(argv)
+
+
+def derive_output_path(input_path: Path) -> Path:
+    return input_path.with_suffix(".png")
+
+
+def convert_jpeg_to_png(input_path: Path, output_path: Path, colorspace: Optional[str] = None, overwrite: bool = False) -> None:
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Output file already exists: {output_path}. Use --overwrite to replace it.")
+
+    with Image.open(input_path) as img:
+        if colorspace:
+            img = img.convert(colorspace)
+        img.save(output_path, format="PNG")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    input_path = Path(args.input)
+    output_path = Path(args.output) if args.output else derive_output_path(input_path)
+
+    convert_jpeg_to_png(
+        input_path=input_path,
+        output_path=output_path,
+        colorspace=args.colorspace,
+        overwrite=args.overwrite,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new jpeg_to_png.py helper to convert JPEG images to PNG with optional colorspace normalization and overwrite protection
- document the new converter alongside other graphics tools with an example invocation
- add a pytest that generates a sample JPEG and verifies conversion to PNG

## Testing
- python -m pytest tests/test_jpeg_to_png.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c849a2c8832592d0922fd55c7af2)